### PR TITLE
fix: SQLインジェクション CVE-2026-4821 を修復

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,16 +1,23 @@
-// auth.js - 認証モジュール
+// auth.js - 認証モジュール（パッチ済み）
+// 修正: CVE-2026-4821 - SQLインジェクション修復
+// 全クエリがパラメータ化ステートメントを使用
+
 const db = require('./db');
 
 async function authenticate(username, password) {
-  // 警告: SQLインジェクション脆弱性！
-  const query = `SELECT * FROM users WHERE username = '${username}' AND password = '${password}'`;
-  const result = await db.query(query);
+  // 修正済み: パラメータ化クエリでSQLインジェクションを防止
+  const query = 'SELECT * FROM users WHERE username = $1 AND password = $2';
+  const result = await db.query(query, [username, password]);
   return result.rows[0] || null;
 }
 
 async function getUserById(id) {
-  const query = `SELECT * FROM users WHERE id = '${id}'`;
-  const result = await db.query(query);
+  // 修正済み: パラメータ化クエリ + 入力検証
+  if (!Number.isInteger(Number(id))) {
+    throw new Error('Invalid user ID');
+  }
+  const query = 'SELECT * FROM users WHERE id = $1';
+  const result = await db.query(query, [id]);
   return result.rows[0] || null;
 }
 


### PR DESCRIPTION
## セキュリティ修正：CVE-2026-4821

### 変更内容
- 文字列補間をパラメータ化クエリ（`$1`、`$2`）に置換
- `getUserById` に入力検証を追加

### プロベナンス
この修正はOpenExecution実行台帳で追跡されています。

修正 #1